### PR TITLE
Make local variables out of nn.sequential members for onnx exportability

### DIFF
--- a/TCN/tcn.py
+++ b/TCN/tcn.py
@@ -15,27 +15,25 @@ class Chomp1d(nn.Module):
 class TemporalBlock(nn.Module):
     def __init__(self, n_inputs, n_outputs, kernel_size, stride, dilation, padding, dropout=0.2):
         super(TemporalBlock, self).__init__()
-        self.conv1 = weight_norm(nn.Conv1d(n_inputs, n_outputs, kernel_size,
-                                           stride=stride, padding=padding, dilation=dilation))
-        self.chomp1 = Chomp1d(padding)
-        self.relu1 = nn.ReLU()
-        self.dropout1 = nn.Dropout(dropout)
+        conv1 = weight_norm(nn.Conv1d(n_inputs, n_outputs, kernel_size,
+                                      stride=stride, padding=padding, dilation=dilation))
+        chomp1 = Chomp1d(padding)
+        relu1 = nn.ReLU()
+        dropout1 = nn.Dropout(dropout)
 
-        self.conv2 = weight_norm(nn.Conv1d(n_outputs, n_outputs, kernel_size,
-                                           stride=stride, padding=padding, dilation=dilation))
-        self.chomp2 = Chomp1d(padding)
-        self.relu2 = nn.ReLU()
-        self.dropout2 = nn.Dropout(dropout)
+        conv2 = weight_norm(nn.Conv1d(n_outputs, n_outputs, kernel_size,
+                                      stride=stride, padding=padding, dilation=dilation))
+        chomp2 = Chomp1d(padding)
+        relu2 = nn.ReLU()
+        dropout2 = nn.Dropout(dropout)
 
-        self.net = nn.Sequential(self.conv1, self.chomp1, self.relu1, self.dropout1,
-                                 self.conv2, self.chomp2, self.relu2, self.dropout2)
+        self.net = nn.Sequential(conv1, chomp1, relu1, dropout1,
+                                 conv2, chomp2, relu2, dropout2)
         self.downsample = nn.Conv1d(n_inputs, n_outputs, 1) if n_inputs != n_outputs else None
         self.relu = nn.ReLU()
-        self.init_weights()
 
-    def init_weights(self):
-        self.conv1.weight.data.normal_(0, 0.01)
-        self.conv2.weight.data.normal_(0, 0.01)
+        conv1.weight.data.normal_(0, 0.01)
+        conv2.weight.data.normal_(0, 0.01)
         if self.downsample is not None:
             self.downsample.weight.data.normal_(0, 0.01)
 


### PR DESCRIPTION
The pytorch onnx exporter doesn't work if parameters are included as members of two modules. This means the pattern of having self.operator and passing self.operator to nn.sequential breaks the ability to export an onnx model.

This updates the TCN network to mirror the implementation of many other networks in pytorch where the operators passed to nn.Sequential are all local variables, and weight initialization is done at construction time to avoid the need for member variables for everything.